### PR TITLE
feat: implement gRPC-based OLAP core service prototype

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -4,3 +4,9 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
+tonic = "0.9"                                  # gRPC 实现库
+prost = "0.11"                                 # Protocol Buffers 编解码库
+tokio = { version = "1", features = ["full"] } # 异步运行时
+
+[build-dependencies]
+tonic-build = "0.9"

--- a/build.rs
+++ b/build.rs
@@ -1,0 +1,8 @@
+fn main() {
+    if let Err(e) = tonic_build::compile_protos("proto/service.proto") {
+        eprintln!("Error compiling proto file: {}", e);
+        std::process::exit(1);
+    }
+    // let out_dir = std::env::var("OUT_DIR").unwrap();
+    // eprintln!(">>> OUT_DIR >>> {}", out_dir);
+}

--- a/proto/service.proto
+++ b/proto/service.proto
@@ -1,0 +1,18 @@
+syntax = "proto3";
+
+package grpc_service;
+
+// 定义请求消息
+message ClientRequest {
+  string message = 1;
+}
+
+// 定义响应消息
+message ServerResponse {
+  string reply = 1;
+}
+
+// 定义服务
+service Greeter {
+  rpc SayHello (ClientRequest) returns (ServerResponse);
+}

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,26 +1,52 @@
-use std::{thread, time};
+// use std::{thread, time};
+use grpc_service::greeter_server::{Greeter, GreeterServer};
+use grpc_service::{ClientRequest, ServerResponse};
+use tonic::{transport::Server, Request, Response, Status};
 
-fn main() {
-    println!("Starting OLAP server...");
-
-    // 模拟服务的主循环
-    let interval = time::Duration::from_secs(5); // 每隔5秒执行一次任务
-
-    loop {
-        if let Err(e) = perform_server_task() {
-            eprintln!("Error: {}", e);
-            break; // 如果发生严重错误，退出程序
-        }
-
-        println!("OLAP server is running...");
-        thread::sleep(interval); // 每5秒执行一次任务
-    }
-
-    println!("OLAP server is shutting down.");
+// 自动生成的 gRPC 模块
+pub mod grpc_service {
+    tonic::include_proto!("grpc_service"); // 包名要与 .proto 文件中的 package 名字匹配
 }
 
-fn perform_server_task() -> Result<(), String> {
-    // 模拟任务，直接返回成功
-    println!("Performing server task...");
-    Ok(()) // 始终返回 Ok，表示任务总是成功
+#[derive(Debug, Default)]
+pub struct MyGreeter {}
+
+#[tonic::async_trait]
+impl Greeter for MyGreeter {
+    async fn say_hello(
+        &self,
+        request: Request<ClientRequest>, // 从客户端接收的请求
+    ) -> Result<Response<ServerResponse>, Status> {
+        println!("Received request: {:?}", request);
+
+        // 获取请求中的数据
+        let client_message = request.into_inner().message;
+
+        // 创建响应
+        let reply = grpc_service::ServerResponse {
+            reply: format!("Hello, {}!", client_message),
+        };
+
+        // 返回响应
+        Ok(Response::new(reply))
+    }
+}
+
+#[tokio::main]
+async fn main() -> Result<(), Box<dyn std::error::Error>> {
+    // 定义服务端监听地址
+    let addr = "127.0.0.1:50052".parse().unwrap();
+
+    // 创建 Greeter 服务实例
+    let greeter = MyGreeter::default();
+
+    println!(">>>>>> EuclidOLAP Server is listening on {} >>>>>>", addr);
+
+    // 启动 gRPC 服务端
+    Server::builder()
+        .add_service(GreeterServer::new(greeter)) // 添加 Greeter 服务
+        .serve(addr) // 启动服务端
+        .await?;
+
+    Ok(())
 }


### PR DESCRIPTION
- Added a basic gRPC server using Tonic to support asynchronous communication.
- Defined ClientRequest and ServerResponse messages and Greeter service in proto file.
- Implemented MyGreeter service logic for handling client requests.
- Configured the server to listen on port 50052 and handle concurrent requests.
- Set up build.rs for auto-compilation of proto files during build.
- Added Default implementation for MyGreeter for streamlined initialization.
- Prepared the service for potential future high-concurrency support.

This commit establishes the foundational structure for the OLAP core service, providing a scalable base for future development.