### PR TITLE
Add support for optional semicolon in MDX expressions

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -187,6 +187,10 @@ fn exe_md_query(ast_selstat: mdx_ast::AstSelectionStatement) -> () {
 #[test]
 fn test_parsing_mdx_00() {
     handle_stat(String::from("MDX"), mdx_demo());
+
+    let mut mdx2 = mdx_demo();
+    mdx2.push(';');
+    handle_stat(String::from("MDX"), mdx2);
 }
 
 // #[test]

--- a/src/mdx_grammar.lalrpop
+++ b/src/mdx_grammar.lalrpop
@@ -26,6 +26,8 @@ extern {
     "{" => Token::CurlyBraceLeft,
     "}" => Token::CurlyBraceRight,
 
+    ";" => Token::Semicolon,
+
     // "var" => Token::KeywordVar,
     // "print" => Token::KeywordPrint,
     // "identifier" => Token::Identifier(<String>),
@@ -162,14 +164,14 @@ pub MdxStatement: mdx_ast::ExtMDXStatement = {
 
 // AstSelectionStatement
 pub SelectionMDX: mdx_ast::AstSelectionStatement = {
-  "select" <axes:Axes> "from" <cube:Segments> => {
+  "select" <axes:Axes> "from" <cube:Segments> (";")? => {
     mdx_ast::AstSelectionStatement {
       axes,
       cube,
       basic_slice: None,
     }
   },
-  "select" <axes:Axes> "from" <cube:Segments> "where" <tuple:TupleWrap> => {
+  "select" <axes:Axes> "from" <cube:Segments> "where" <tuple:TupleWrap> (";")? => {
     mdx_ast::AstSelectionStatement {
       axes,
       cube,


### PR DESCRIPTION
- Updated `src/mdx_grammar.lalrpop` to allow parsing MDX expressions with an optional trailing semicolon.
- Added a new test case in `src/main.rs` to validate the parsing of MDX expressions ending with a semicolon.